### PR TITLE
Use default configuration if no setup

### DIFF
--- a/lua/stabilize.lua
+++ b/lua/stabilize.lua
@@ -79,7 +79,7 @@ function M.handle_closed()
 end
 
 function M.setup(setup_cfg)
-	if setup_cfg then cfg = vim.tbl_deep_extend("force", cfg, setup_cfg) end
+	setup_cfg = vim.tbl_deep_extend("force", cfg, setup_cfg or {})
 	cmd [[
 	augroup Stabilize
 		autocmd!


### PR DESCRIPTION
Hello, 
If no configuration was passed in setup, the default setups where not used.
This is now fixed with this PR, as you can test

![Capture d’écran 2021-10-19 à 07 19 19](https://user-images.githubusercontent.com/5306901/137848299-c091667d-7148-4da4-91d8-9e53eddbba2f.png)

Results in

![Capture d’écran 2021-10-19 à 07 19 31](https://user-images.githubusercontent.com/5306901/137848316-56c42c17-f2f7-4388-b10f-a1b46d41c454.png)

