### PR TITLE
fix: replaced 'nvim_exec_autocmd' with 'nvim_exec_autocmds'

### DIFF
--- a/lua/stabilize.lua
+++ b/lua/stabilize.lua
@@ -109,7 +109,7 @@ function M.setup(setup_cfg)
 
 	if cfg.nested then
 		api.nvim_create_autocmd(cfg.nested, { group = group, callback = function()
-			api.nvim_exec_autocmd("User", { pattern = "StabilizeRestore" })
+			api.nvim_exec_autocmds("User", { pattern = "StabilizeRestore" })
 		end})
 	end
 end


### PR DESCRIPTION
In [neovim:9d40b2fda96709a8219369316a5768ca4b689e4f](https://github.com/neovim/neovim/pull/17938) `nvim_exec_autocmd` got replaced with `nvim_exec_autocmds` ( [diff](https://github.com/neovim/neovim/pull/17938/commits/9d40b2fda96709a8219369316a5768ca4b689e4f#diff-049c763c994eef03c4beafabcc733d1ff66af66630bb74c2dbd303182683e876L712) )

Fixes issue #18 